### PR TITLE
fix: update callback function identification logic

### DIFF
--- a/detectors/near_core.h
+++ b/detectors/near_core.h
@@ -39,7 +39,8 @@ namespace Rustle {
     auto const regexRound           = llvm::Regex("[0-9]+std[0-9]+.+[0-9]+(try_round|round)[0-9]+");
     auto const regexPartialEq       = llvm::Regex("(core..cmp..PartialEq)");
     auto const regexPartialOrd      = llvm::Regex("(core[0-9]+cmp[0-9]+PartialOrd)");
-    auto const regexPromiseResult   = llvm::Regex("near_sdk[0-9]+environment[0-9]+env[0-9]+promise_result[0-9]+");
+    auto const regexPromiseResult =
+        llvm::Regex("(near_sdk[0-9]+environment[0-9]+env[0-9]+(promise_result|promise_results_count)[0-9]+)|(near_sdk[0-9]+utils[0-9]+(is_promise_success|promise_result_as_success)[0-9]+)");
 
     class Logger {
       private:

--- a/detectors/non-callback-private.py
+++ b/detectors/non-callback-private.py
@@ -35,7 +35,7 @@ with open(TMP_PATH + "/.non-callback-private.tmp", "w") as out_file:
             func_name = func["name"]
             func_type = "Function"
             for cb_name in callback_func_set:
-                if structFuncNameMatch(cb_name[0], func["struct"], func["struct_trait"], func_name, path):
+                if  func_name == cb_name[0] or structFuncNameMatch(cb_name[0], func["struct"], func["struct_trait"], func_name, path):
                     if " (callback)" not in func_type:
                         func_type += " (callback)"
                     break

--- a/detectors/non-private-callback.py
+++ b/detectors/non-private-callback.py
@@ -35,7 +35,7 @@ with open(TMP_PATH + "/.non-private-callback.tmp", "w") as out_file:
             func_name = func["name"]
             func_type = "Function"
             for cb_name in callback_func_set:
-                if structFuncNameMatch(cb_name[0], func["struct"], func["struct_trait"], func_name, path):
+                if func_name == cb_name[0] or structFuncNameMatch(cb_name[0], func["struct"], func["struct_trait"], func_name, path):
                     if " (callback)" not in func_type:
                         func_type += " (callback)"
                     break


### PR DESCRIPTION
Now it support identify callback function with:

1. macro `#[callback]`
2. `near_sdk::utils::is_promise_success` and `near_sdk::utils::promise_result_as_success`

I have passed the script/unit_test.sh